### PR TITLE
fix(pouch-utils): Fix pouchdb-promise's ES6 import with _interopDefault

### DIFF
--- a/lib/pouch-utils.js
+++ b/lib/pouch-utils.js
@@ -1,6 +1,11 @@
 'use strict';
 
-var Promise = require('pouchdb-promise');
+/* istanbul ignore next */
+function _interopDefault (ex) {
+  return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex;
+}
+
+var Promise = _interopDefault(require('pouchdb-promise'));
 /* istanbul ignore next */
 exports.once = function (fun) {
   var called = false;


### PR DESCRIPTION
Recent PR #34 upgraded `pouchdb-promise` package version from 5.4.3 to
6.4.3.

This new version is shipped with two module flavors: the old fashioned
CommonJS module syntax (`lib/index.js`) and the new ES6 module syntax
(`lib/index.es.js`).

If you build using ES Module then you'll get an error at runtime:
`Promise is not a constructor` because when `pouch-utils.js` requires
`pouchdb-promise` it expects `Promise` is assigned the value of the
default export. It's not the case with ES6 module as it's in the
`default` property.

Similar to pouchdb-community/worker-pouch#40, this PR adds the
`_interopDefault` function so both cases work fine.